### PR TITLE
feature: add options.tracer

### DIFF
--- a/app/middleware/zipkinMW.js
+++ b/app/middleware/zipkinMW.js
@@ -47,6 +47,10 @@ function formatRequestUrl(req) {
 let tracer;
 
 async function generateTracer(options){
+    if(options && options.tracer){
+        tracer = options.tracer
+        return
+    }
     let protocalHeader = 'http://';
     if(options && options.httpsOn){
         protocalHeader = 'https://';


### PR DESCRIPTION
## What is this feature?

A very simple improvement to solve #3 .
It allows to pass a custom tracer,
and then options{ targetServer, targetApi, jsonEncoder, httpsOn, consoleRecorder } will be ignored

Thank you

